### PR TITLE
Add right version of gulp

### DIFF
--- a/versions-of-dependencies.md
+++ b/versions-of-dependencies.md
@@ -114,3 +114,13 @@ Instalação do `css-loader`:
 ```
 npm i --save-dev css-loader@0
 ```
+
+### M2#A51
+
+Instalação do `gulp`:
+
+```
+npm i --save-dev gulp@3.9.1
+<!-- ou -->
+yarn add --dev gulp@3.9.1
+```


### PR DESCRIPTION
Oi, professor! 

A versão utilizada no boilerplate é a que adicionei no pull request. Na [versão 4](https://medium.com/gulpjs/version-4-now-default-92c6cd4beb45), o gulp modificou a assinatura das tasks, o que fez com que o código das tasks apresentado na aula não funcionasse. 

Qualquer coisa é só falar que altero o PR aqui.

@fdaciuk 