### PR TITLE
Add right version of clean-webpack-plugin

### DIFF
--- a/versions-of-dependencies.md
+++ b/versions-of-dependencies.md
@@ -144,3 +144,11 @@ Instalação do `gulp`:
 ```
 npm i --save-dev gulp@3.9.1
 ```
+
+### M2#A78
+
+Instalação do `clean-webpack-plugin`:
+
+```
+npm i --save-dev clean-webpack-plugin@0.1.16
+```


### PR DESCRIPTION
Oi Professor!

A versão atual deste plugin eliminou a possibilidade de [especificar um array como 1º parâmetro da invocação](https://github.com/johnagan/clean-webpack-plugin#options-and-defaults-optional) do `new CleanWebpackPlugin()`. Para declarar esse array, como demonstrado na aula, é necessário que a versão seja a `0.1.16`.

@fdaciuk 